### PR TITLE
Replace deprecated compare_and_swap with compare_exchange

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -497,9 +497,10 @@ impl State {
     /// Notifies a sleeping ticker.
     #[inline]
     fn notify(&self) {
-        if !self
+        if self
             .notified
-            .compare_and_swap(false, true, Ordering::SeqCst)
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
         {
             let waker = self.sleepers.lock().unwrap().notify();
             if let Some(w) = waker {


### PR DESCRIPTION
`compare_and_swap` is deprecated in 1.50. (https://github.com/rust-lang/rust/pull/79261)
This patch replaces the uses of `compare_and_swap` with `compare_exchange`.

See also the document about `compare_and_swap` -> `compare_exchange(_weak)` migration: https://doc.rust-lang.org/nightly/core/sync/atomic/struct.AtomicUsize.html#migrating-to-compare_exchange-and-compare_exchange_weak