### PR TITLE
Remove readme field from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ homepage = "https://github.com/smol-rs/async-executor"
 documentation = "https://docs.rs/async-executor"
 keywords = ["asynchronous", "executor", "single", "multi", "spawn"]
 categories = ["asynchronous", "concurrency"]
-readme = "README.md"
 
 [dependencies]
 async-task = "4.0.0"


### PR DESCRIPTION
Since 1.46, cargo can automatically detect the value of the readme field.