### PR TITLE
Bump to v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 1.4.1
+
+- Remove dependency on deprecated `vec-arena`. (#23)
+
 # Version 1.4.0
 
 - Add `Executor::is_empty()` and `LocalExecutor::is_empty()`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,9 @@
 [package]
 name = "async-executor"
-version = "1.4.0"
+# When publishing a new version:
+# - Update CHANGELOG.md
+# - Create "v1.x.y" git tag
+version = "1.4.1"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 description = "Async executor"


### PR DESCRIPTION
Changes:
- Remove dependency on deprecated `vec-arena`. (#23)
