### PR TITLE
Add block_in_place method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -837,7 +837,7 @@ impl Runner<'_> {
     /// Waits for the next runnable task to run.
     async fn runnable(&self) -> Runnable {
         // Store the current thread that is running this runner.
-        // 
+        //
         // Relaxed ordering is fine here since a SeqCst fence is issued before the value is
         // actually loaded.
         self.local.thread.store(thread_id(), Ordering::Relaxed);


### PR DESCRIPTION
This PR adds a `block_in_place()` method to the `Executor` structure. Similarly to its equivalent in `tokio`, it clears the local queues in order to prevent other tasks from being blocked on the provided method and then runs the closure. This is sometimes necessary in cases where `blocking::unblock()` cannot be used.

Discussion questions:

- How do we feel about the name `block_in_place()`? Since it's not really what it does (it's more of an `empty_and_run()` type of function), but it may be familiar to users coming from `tokio`.
- I did not implement this function on `LocalExecutor` because it doesn't make much sense for a single-threaded runtime. However, it may be useful to clear the entire queue in order to run a blocking function, even if it's very inefficient. I didn't add it because I'm worried about the footgun, but it may be useful, if not under another name. 