### PR TITLE
feat: Push tasks directly to the local runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install Rust
         run: rustup update stable
-      - run: cargo clippy --all-features --tests --examples
+      - run: cargo clippy --all-features --all-targets
 
   fmt:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ exclude = ["/.*"]
 [dependencies]
 async-lock = "2.6"
 async-task = "4.0.0"
+atomic-waker = "1.1.0"
 concurrent-queue = "2.0.0"
 fastrand = "1.3.4"
 futures-lite = "1.11.0"


### PR DESCRIPTION
Basically implements #22 but in a simpler and less dependency-heavy way.

I'm marking this as draft for now, since the current implementation here actually seems less performant than the `master` branch implementation. I'll optimize this later.