### PR TITLE
alg: Push tasks directly to the local runner, take 2

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -879,7 +879,7 @@ impl LocalQueue {
                 // Restore the old local queue on drop.
                 let _guard = CallOnDrop(move || {
                     let old = old.take();
-                    LOCAL_QUEUE.with(move |slot| {
+                    let _ = LOCAL_QUEUE.try_with(move |slot| {
                         *slot.borrow_mut() = old;
                     });
                 });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@
 
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 
+use std::cell::RefCell;
 use std::fmt;
 use std::future::Future;
 use std::marker::PhantomData;
@@ -229,29 +230,51 @@ impl<'a> Executor<'a> {
         let runner = Runner::new(self.state());
         let mut rng = fastrand::Rng::new();
 
-        // A future that runs tasks forever.
-        let run_forever = async {
-            loop {
-                for _ in 0..200 {
-                    let runnable = runner.runnable(&mut rng).await;
-                    runnable.run();
-                }
-                future::yield_now().await;
-            }
-        };
+        // Set the local queue while we're running.
+        LocalQueue::set(&runner.local, {
+            let runner = &runner;
+            async move {
+                // A future that runs tasks forever.
+                let run_forever = async {
+                    loop {
+                        for _ in 0..200 {
+                            let runnable = runner.runnable(&mut rng).await;
+                            runnable.run();
+                        }
+                        future::yield_now().await;
+                    }
+                };
 
-        // Run `future` and `run_forever` concurrently until `future` completes.
-        future.or(run_forever).await
+                // Run `future` and `run_forever` concurrently until `future` completes.
+                future.or(run_forever).await
+            }
+        })
+        .await
     }
 
     /// Returns a function that schedules a runnable task when it gets woken up.
     fn schedule(&self) -> impl Fn(Runnable) + Send + Sync + 'static {
         let state = self.state().clone();
 
-        // TODO(stjepang): If possible, push into the current local queue and notify the ticker.
+        // If possible, push into the current local queue and notify the ticker.
         move |runnable| {
-            state.queue.push(runnable).unwrap();
-            state.notify();
+            let mut runnable = Some(runnable);
+
+            // Try to push into the local queue.
+            LocalQueue::with(|local_queue| {
+                if let Err(e) = local_queue.queue.push(runnable.take().unwrap()) {
+                    runnable = Some(e.into_inner());
+                    return;
+                }
+
+                local_queue.waker.wake_by_ref();
+            });
+
+            // If the local queue push failed, just push to the global queue.
+            if let Some(runnable) = runnable {
+                state.queue.push(runnable).unwrap();
+                state.notify();
+            }
         }
     }
 
@@ -819,6 +842,92 @@ impl Drop for Runner<'_> {
     }
 }
 
+/// The state of the currently running local queue.
+struct LocalQueue {
+    /// The concurrent queue.
+    queue: Arc<ConcurrentQueue<Runnable>>,
+
+    /// The waker for the runnable.
+    waker: Waker,
+}
+
+impl LocalQueue {
+    /// Run a function with the current local queue.
+    fn with<R>(f: impl FnOnce(&LocalQueue) -> R) -> Option<R> {
+        std::thread_local! {
+            /// The current local queue.
+            static LOCAL_QUEUE: RefCell<Option<LocalQueue>> = RefCell::new(None);
+        }
+
+        impl LocalQueue {
+            /// Run a function with a set local queue.
+            async fn set<F>(queue: &Arc<ConcurrentQueue<Runnable>>, fut: F) -> F::Output
+            where
+                F: Future,
+            {
+                // Store the local queue and the current waker.
+                let mut old = with_waker(|waker| {
+                    LOCAL_QUEUE.with(move |slot| {
+                        let mut slot = slot.borrow_mut();
+                        slot.replace(LocalQueue {
+                            queue: queue.clone(),
+                            waker: waker.clone(),
+                        })
+                    })
+                })
+                .await;
+
+                // Restore the old local queue on drop.
+                let _guard = CallOnDrop(move || {
+                    let old = old.take();
+                    LOCAL_QUEUE.with(move |slot| {
+                        let mut slot = slot.borrow_mut();
+                        *slot = old;
+                    });
+                });
+
+                // Pin the future.
+                futures_lite::pin!(fut);
+
+                // Run it such that the waker is updated every time it's polled.
+                future::poll_fn(move |cx| {
+                    LOCAL_QUEUE
+                        .try_with({
+                            let waker = cx.waker();
+                            move |slot| {
+                                let mut slot = slot.borrow_mut();
+                                let qaw = slot.as_mut().expect("missing local queue");
+
+                                // If we've been replaced, just ignore the slot.
+                                if !Arc::ptr_eq(&qaw.queue, queue) {
+                                    return;
+                                }
+
+                                // Update the waker, if it has changed.
+                                if !qaw.waker.will_wake(waker) {
+                                    qaw.waker = waker.clone();
+                                }
+                            }
+                        })
+                        .ok();
+
+                    // Poll the future.
+                    fut.as_mut().poll(cx)
+                })
+                .await
+            }
+        }
+
+        LOCAL_QUEUE
+            .try_with(|local_queue| {
+                let local_queue = local_queue.borrow();
+                local_queue.as_ref().map(f)
+            })
+            .ok()
+            .flatten()
+    }
+}
+
 /// Steals some items from one queue into another.
 fn steal<T>(src: &ConcurrentQueue<T>, dest: &ConcurrentQueue<T>) {
     // Half of `src`'s length rounded up.
@@ -911,10 +1020,19 @@ fn debug_executor(executor: &Executor<'_>, name: &str, f: &mut fmt::Formatter<'_
 }
 
 /// Runs a closure when dropped.
-struct CallOnDrop<F: Fn()>(F);
+struct CallOnDrop<F: FnMut()>(F);
 
-impl<F: Fn()> Drop for CallOnDrop<F> {
+impl<F: FnMut()> Drop for CallOnDrop<F> {
     fn drop(&mut self) {
         (self.0)();
     }
+}
+
+/// Run a closure with the current waker.
+fn with_waker<F: FnOnce(&Waker) -> R, R>(f: F) -> impl Future<Output = R> {
+    let mut f = Some(f);
+    future::poll_fn(move |cx| {
+        let f = f.take().unwrap();
+        Poll::Ready(f(cx.waker()))
+    })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -868,8 +868,7 @@ impl LocalQueue {
                 // Store the local queue and the current waker.
                 let mut old = with_waker(|waker| {
                     LOCAL_QUEUE.with(move |slot| {
-                        let mut slot = slot.borrow_mut();
-                        slot.replace(LocalQueue {
+                        slot.borrow_mut().replace(LocalQueue {
                             queue: queue.clone(),
                             waker: waker.clone(),
                         })
@@ -881,8 +880,7 @@ impl LocalQueue {
                 let _guard = CallOnDrop(move || {
                     let old = old.take();
                     LOCAL_QUEUE.with(move |slot| {
-                        let mut slot = slot.borrow_mut();
-                        *slot = old;
+                        *slot.borrow_mut() = old;
                     });
                 });
 
@@ -919,10 +917,7 @@ impl LocalQueue {
         }
 
         LOCAL_QUEUE
-            .try_with(|local_queue| {
-                let local_queue = local_queue.borrow();
-                local_queue.as_ref().map(f)
-            })
+            .try_with(|local_queue| local_queue.borrow().as_ref().map(f))
             .ok()
             .flatten()
     }


### PR DESCRIPTION
This PR supersedes #36 by pushing tasks directly to the local runner. A thread-local variable is used to cache a reference to the current `Runner` which is then used by `schedule()` to push tasks directly to the local queue.

This has led to significant improvements in some of our benchmarks! Around 10% in the main use cases, and 77% in the yield now case.

![image](https://user-images.githubusercontent.com/19805233/224430708-9be20bf9-4043-43b4-9e22-151fe3e69299.png)
