### PR TITLE
replace `num_cpus` crate with `std::thread`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ async-channel = "1.4.1"
 async-io = "1.1.9"
 criterion = { version = "0.4.0", default-features = false, features = ["cargo_bench_support"] }
 easy-parallel = "3.1.0"
-num_cpus = "1.13.0"
 once_cell = "1.16.0"
 
 [[bench]]

--- a/benches/executor.rs
+++ b/benches/executor.rs
@@ -1,4 +1,5 @@
 use std::future::Future;
+use std::thread::available_parallelism;
 
 use async_executor::Executor;
 use criterion::{criterion_group, criterion_main, Criterion};
@@ -11,7 +12,11 @@ const LIGHT_TASKS: usize = 25_000;
 static EX: Executor<'_> = Executor::new();
 
 fn run(f: impl FnOnce(), multithread: bool) {
-    let limit = if multithread { num_cpus::get() } else { 1 };
+    let limit = if multithread {
+        available_parallelism().unwrap().get()
+    } else {
+        1
+    };
 
     let (s, r) = async_channel::bounded::<()>(1);
     easy_parallel::Parallel::new()


### PR DESCRIPTION
Removes the dev dependency on `num_cpus`