### PR TITLE
v1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 1.5.2
+
+- Add thread-local task queue optimizations, allowing new tasks to avoid using the global queue. (#37)
+- Update `fastrand` to v2. (#45)
+
 # Version 1.5.1
 
 - Implement a better form of debug output for Executor and LocalExecutor. (#33) 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-executor"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v1.x.y" git tag
-version = "1.5.1"
+version = "1.5.2"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 rust-version = "1.48"


### PR DESCRIPTION
- Add thread-local task queue optimizations, allowing new tasks to avoid using the global queue. (#37)
- Update `fastrand` to v2. (#45)