### PR TITLE
v1.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 1.5.3
+
+- Fix an accidental breaking change in v1.5.2, where `ex.run()` was no longer `Send`. (#50)
+- Remove the unused `memchr` dependency. (#51)
+
 # Version 1.5.2
 
 - Add thread-local task queue optimizations, allowing new tasks to avoid using the global queue. (#37)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-executor"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v1.x.y" git tag
-version = "1.5.2"
+version = "1.5.3"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 rust-version = "1.61"


### PR DESCRIPTION
- Fix an accidental breaking change in v1.5.2, where `ex.run()` was no longer `Send`. (#50)
- Remove the unused `memchr` dependency. (#51)