### PR TITLE
v1.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 1.5.4
+
+- Fix a panic that could happen when two concurrent `run()` calls are made and the thread local task slot is left as `None`. (#55)
+
 # Version 1.5.3
 
 - Fix an accidental breaking change in v1.5.2, where `ex.run()` was no longer `Send`. (#50)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-executor"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v1.x.y" git tag
-version = "1.5.3"
+version = "1.5.4"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 rust-version = "1.61"


### PR DESCRIPTION
- Fix a panic that could happen when two concurrent `run()` calls are made and the thread local task slot is left as `None`. (#55)