### PR TITLE
Bump async-io, async-lock and futures-lite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,20 +15,21 @@ categories = ["asynchronous", "concurrency"]
 exclude = ["/.*"]
 
 [dependencies]
-async-lock = "2.6"
+async-lock = "3.0.0"
 async-task = "4.0.0"
 concurrent-queue = "2.0.0"
 fastrand = "2.0.0"
-futures-lite = { version = "1.11.0", default-features = false }
+futures-lite = { version = "2.0.0", default-features = false }
 slab = "0.4.4"
 
 [dev-dependencies]
 async-channel = "2.0.0"
-async-io = "1.1.9"
+async-io = "2.1.0"
 criterion = { version = "0.4.0", default-features = false, features = ["cargo_bench_support"] }
 easy-parallel = "3.1.0"
 event-listener = "3.0.0"
 fastrand = "2.0.0"
+futures-lite = "2.0.0"
 once_cell = "1.16.0"
 
 [[bench]]

--- a/tests/drop.rs
+++ b/tests/drop.rs
@@ -38,6 +38,7 @@ fn executor_cancels_everything() {
     assert_eq!(DROP.load(Ordering::SeqCst), 1);
 }
 
+#[cfg(not(miri))]
 #[test]
 fn leaked_executor_leaks_everything() {
     static DROP: AtomicUsize = AtomicUsize::new(0);

--- a/tests/drop.rs
+++ b/tests/drop.rs
@@ -1,3 +1,4 @@
+#[cfg(not(miri))]
 use std::mem;
 use std::panic::catch_unwind;
 use std::sync::atomic::{AtomicUsize, Ordering};


### PR DESCRIPTION
Closes #66, #67 and #68