### PR TITLE
v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 1.7.0
+
+- Bump `async-lock` and `futures-lite` to their latest versions. (#70)
+
 # Version 1.6.0
 
 - Remove the thread-local queue optimization, as it caused a number of bugs in production use cases. (#61)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-executor"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v1.x.y" git tag
-version = "1.6.0"
+version = "1.7.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 rust-version = "1.61"


### PR DESCRIPTION
- Bump `async-lock` and `futures-lite` to their latest versions. (#70)
