### PR TITLE
Use once_cell instead of async-lock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,11 @@ categories = ["asynchronous", "concurrency"]
 exclude = ["/.*"]
 
 [dependencies]
-async-lock = "3.0.0"
 async-task = "4.0.0"
 concurrent-queue = "2.0.0"
 fastrand = "2.0.0"
 futures-lite = { version = "2.0.0", default-features = false }
+once_cell = "1.18.0"
 slab = "0.4.4"
 
 [dev-dependencies]
@@ -30,7 +30,6 @@ easy-parallel = "3.1.0"
 event-listener = "3.0.0"
 fastrand = "2.0.0"
 futures-lite = "2.0.0"
-once_cell = "1.16.0"
 
 [[bench]]
 name = "executor"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,10 +35,10 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, RwLock, TryLockError};
 use std::task::{Poll, Waker};
 
-use once_cell::sync::OnceCell;
 use async_task::Runnable;
 use concurrent_queue::ConcurrentQueue;
 use futures_lite::{future, prelude::*};
+use once_cell::sync::OnceCell;
 use slab::Slab;
 
 #[doc(no_inline)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, RwLock, TryLockError};
 use std::task::{Poll, Waker};
 
-use async_lock::OnceCell;
+use once_cell::sync::OnceCell;
 use async_task::Runnable;
 use concurrent_queue::ConcurrentQueue;
 use futures_lite::{future, prelude::*};
@@ -263,7 +263,7 @@ impl<'a> Executor<'a> {
 
     /// Returns a reference to the inner state.
     fn state(&self) -> &Arc<State> {
-        self.state.get_or_init_blocking(|| Arc::new(State::new()))
+        self.state.get_or_init(|| Arc::new(State::new()))
     }
 }
 


### PR DESCRIPTION
Basic fix for getting more recent versions of `Executor` to compile on WASM is to avoid `async-lock` as that no longer will work for the `OnceCell` usage within `wasm32` contexts. Unfortunately, adding the test suites for WASM requires [`async-io` to support web timers](https://github.com/smol-rs/async-io/pull/153), so perhaps that needs to be fixed in `async-io` first before adding additional CI checks here for `async-executor`.

Fixes #72 