### PR TITLE
v1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 1.7.1
+
+- Fix compilation under WebAssembly targets (#75).
+- Add a disclaimer indicating that this is a reference executor (#74).
+
 # Version 1.7.0
 
 - Bump `async-lock` and `futures-lite` to their latest versions. (#70)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-executor"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v1.x.y" git tag
-version = "1.7.0"
+version = "1.7.1"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 rust-version = "1.61"


### PR DESCRIPTION
- Fix compilation under WebAssembly targets (#75).
- Add a disclaimer indicating that this is a reference executor (#74).
