### PR TITLE
Fix dev-dependency issue on WASM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Install Rust
         run: rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
       - run: rustup target add wasm32-unknown-unknown
+      - uses: taiki-e/install-action@cargo-hack
       - run: cargo build --all --all-features --all-targets
         if: startsWith(matrix.rust, 'nightly')
       - name: Run cargo check (without dev-dependencies to catch missing feature flags)
@@ -45,6 +46,7 @@ jobs:
         run: cargo check -Z features=dev_dep
       - run: cargo test
       - run: cargo check --all --all-features --target wasm32-unknown-unknown
+      - run: cargo hack build --all --all-features --target wasm32-unknown-unknown --no-dev-deps
 
   msrv:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ name = "async-executor"
 # - Create "v1.x.y" git tag
 version = "1.7.1"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
-edition = "2018"
+edition = "2021"
 rust-version = "1.61"
 description = "Async executor"
 license = "Apache-2.0 OR MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ fastrand = "2.0.0"
 futures-lite = { version = "2.0.0", default-features = false }
 slab = "0.4.4"
 
+[target.'cfg(target_family = "wasm")'.dependencies]
+futures-lite = { version = "2.0.0", default-features = false, features = ["std"] }
+
 [dev-dependencies]
 async-channel = "2.0.0"
 async-io = "2.1.0"


### PR DESCRIPTION
`futures-lite` in the dev dependencies added a `block_on` call that was not present in the WASM build, causing a compile error. This PR makes sure that the `std` feature of `futures-lite` is enabled in Cargo.toml.
    
This also adds a CI check to ensure that this doesn't happen again.
