### PR TITLE
Propagate panics in tasks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ use std::sync::{Arc, Mutex, RwLock, TryLockError};
 use std::task::{Poll, Waker};
 
 use async_lock::OnceCell;
-use async_task::Runnable;
+use async_task::{Builder, Runnable};
 use concurrent_queue::ConcurrentQueue;
 use futures_lite::{future, prelude::*};
 use slab::Slab;
@@ -159,7 +159,11 @@ impl<'a> Executor<'a> {
         };
 
         // Create the task and register it in the set of active tasks.
-        let (runnable, task) = unsafe { async_task::spawn_unchecked(future, self.schedule()) };
+        let (runnable, task) = unsafe {
+            Builder::new()
+                .propagate_panic(true)
+                .spawn_unchecked(|()| future, self.schedule())
+        };
         active.insert(runnable.waker());
 
         runnable.schedule();
@@ -402,7 +406,11 @@ impl<'a> LocalExecutor<'a> {
         };
 
         // Create the task and register it in the set of active tasks.
-        let (runnable, task) = unsafe { async_task::spawn_unchecked(future, self.schedule()) };
+        let (runnable, task) = unsafe {
+            Builder::new()
+                .propagate_panic(true)
+                .spawn_unchecked(|()| future, self.schedule())
+        };
         active.insert(runnable.waker());
 
         runnable.schedule();

--- a/tests/panic_prop.rs
+++ b/tests/panic_prop.rs
@@ -1,0 +1,14 @@
+use async_executor::Executor;
+use futures_lite::{future, prelude::*};
+
+#[test]
+fn test_panic_propagation() {
+    let ex = Executor::new();
+    let task = ex.spawn(async { panic!("should be caught by the task") });
+
+    // Running the executor should not panic.
+    assert!(ex.try_tick());
+
+    // Polling the task should.
+    assert!(future::block_on(task.catch_unwind()).is_err());
+}


### PR DESCRIPTION
After smol-rs/async-task#37 I meant to add this to the executor. This
commit makes it so all panics are surfaced in the tasks that the user
calls. Hopefully this improves ergonomics.
