### PR TITLE
v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 1.8.0
+
+- When spawned tasks panic, the panic is caught and then surfaced in the spawned
+ `Task`. Previously, the panic would be surfaced in `tick()` or `run()`. (#78)
+
 # Version 1.7.2
 
 - Fix compilation under WebAssembly targets (#77).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-executor"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v1.x.y" git tag
-version = "1.7.2"
+version = "1.8.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2021"
 rust-version = "1.61"


### PR DESCRIPTION
- When spawned tasks panic, the panic is caught and then surfaced in the spawned
 `Task`. Previously, the panic would be surfaced in `tick()` or `run()`. (#78)
