### PR TITLE
minimum supported async-task version is 4.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["/.*"]
 
 [dependencies]
 async-lock = "3.0.0"
-async-task = "4.0.0"
+async-task = "4.4.0"
 concurrent-queue = "2.0.0"
 fastrand = "2.0.0"
 futures-lite = { version = "2.0.0", default-features = false }


### PR DESCRIPTION
This crate depends on async_task::Builder, which was introduced in 4.4.0

Detected with [cargo-minimal-versions](https://github.com/taiki-e/cargo-minimal-versions)