### PR TITLE
Use actual thread local queues instead of using a RwLock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ concurrent-queue = "2.0.0"
 fastrand = "2.0.0"
 futures-lite = { version = "2.0.0", default-features = false }
 slab = "0.4.4"
+thread_local = "1.0"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 futures-lite = { version = "2.0.0", default-features = false, features = ["std"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -787,7 +787,7 @@ impl Runner<'_> {
 
                 // Try stealing from the global queue.
                 if let Ok(r) = self.state.queue.pop() {
-                    steal(&self.state.queue, &local_queue);
+                    steal(&self.state.queue, local_queue);
                     return Some(r);
                 }
 
@@ -804,11 +804,11 @@ impl Runner<'_> {
                     .take(n);
 
                 // Remove this runner's local queue.
-                let iter = iter.filter(|local| !core::ptr::eq(local, &local_queue));
+                let iter = iter.filter(|local| !core::ptr::eq(*local, local_queue));
 
                 // Try stealing from each local queue in the list.
                 for local in iter {
-                    steal(local, &local_queue);
+                    steal(local, local_queue);
                     if let Ok(r) = local_queue.pop() {
                         return Some(r);
                     }
@@ -823,7 +823,7 @@ impl Runner<'_> {
 
         if ticks % 64 == 0 {
             // Steal tasks from the global queue to ensure fair task scheduling.
-            steal(&self.state.queue, &local_queue);
+            steal(&self.state.queue, local_queue);
         }
 
         runnable

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -780,8 +780,6 @@ impl Runner<'_> {
         let runnable = self
             .ticker
             .runnable_with(|| {
-                let local_queue = self.state.local_queues.get_or_default();
-
                 // Try the local queue.
                 if let Ok(r) = local_queue.pop() {
                     return Some(r);


### PR DESCRIPTION
Currently, runner local queues rely on a `RwLock<Vec<Arc<ConcurrentQueue>>>>` to store the queues instead of using actual thread-local storage.

This adds `thread_local` as a dependency, but this should allow the executor to work steal without needing to hold a lock.

This may be useful for resolving #62, as the thread-local queue is easily accessible when rescheduling a runnable.