### PR TITLE
Weaken the atomic orderings for notification

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -541,7 +541,7 @@ impl State {
     fn notify(&self) {
         if self
             .notified
-            .compare_exchange(false, true, Ordering::Release, Ordering::Acquire)
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
             .is_ok()
         {
             let waker = self.sleepers.lock().unwrap().notify();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -541,7 +541,7 @@ impl State {
     fn notify(&self) {
         if self
             .notified
-            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .compare_exchange(false, true, Ordering::Release, Ordering::Acquire)
             .is_ok()
         {
             let waker = self.sleepers.lock().unwrap().notify();
@@ -673,7 +673,7 @@ impl Ticker<'_> {
 
         self.state
             .notified
-            .swap(sleepers.is_notified(), Ordering::SeqCst);
+            .store(sleepers.is_notified(), Ordering::Release);
 
         true
     }
@@ -687,7 +687,7 @@ impl Ticker<'_> {
 
             self.state
                 .notified
-                .swap(sleepers.is_notified(), Ordering::SeqCst);
+                .store(sleepers.is_notified(), Ordering::Release);
         }
     }
 
@@ -735,7 +735,7 @@ impl Drop for Ticker<'_> {
 
             self.state
                 .notified
-                .swap(sleepers.is_notified(), Ordering::SeqCst);
+                .store(sleepers.is_notified(), Ordering::Release);
 
             // If this ticker was notified, then notify another ticker.
             if notified {


### PR DESCRIPTION
Meant to be a separate part of #94. The atomic orderings on `State::notified` might be too strong, as it's primarily being used as a deterrent against waking up too many threads. This PR weakens their sequentially consistent operations to Acquire/Release.