### PR TITLE
Avoid redundant lookups in the active slab when spawning new tasks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -399,7 +399,8 @@ impl<'a> LocalExecutor<'a> {
         let mut active = self.inner().state().active.lock().unwrap();
 
         // Remove the task from the set of active tasks when the future finishes.
-        let index = active.vacant_entry().key();
+        let entry = active.vacant_entry();
+        let index = entry.key();
         let state = self.inner().state().clone();
         let future = async move {
             let _guard = CallOnDrop(move || drop(state.active.lock().unwrap().try_remove(index)));
@@ -412,7 +413,7 @@ impl<'a> LocalExecutor<'a> {
                 .propagate_panic(true)
                 .spawn_unchecked(|()| future, self.schedule())
         };
-        active.insert(runnable.waker());
+        entry.insert(runnable.waker());
 
         runnable.schedule();
         task

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,8 @@ impl<'a> Executor<'a> {
         let mut active = self.state().active.lock().unwrap();
 
         // Remove the task from the set of active tasks when the future finishes.
-        let index = active.vacant_entry().key();
+        let entry = active.vacant_entry();
+        let index = entry.key();
         let state = self.state().clone();
         let future = async move {
             let _guard = CallOnDrop(move || drop(state.active.lock().unwrap().try_remove(index)));
@@ -164,7 +165,7 @@ impl<'a> Executor<'a> {
                 .propagate_panic(true)
                 .spawn_unchecked(|()| future, self.schedule())
         };
-        active.insert(runnable.waker());
+        entry.insert(runnable.waker());
 
         runnable.schedule();
         task


### PR DESCRIPTION
The fetch of a vacant entry just to get the key then inserting it when spawning tasks works, but does an extra unnecessary Slab lookup. This PR changes it so that the located entry is directly inserted to.