### PR TITLE
Use wrapping_add to avoid a panic in debug mode

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -853,7 +853,7 @@ impl Runner<'_> {
             .await;
 
         // Bump the tick counter.
-        self.ticks += 1;
+        self.ticks = self.ticks.wrapping_add(1);
 
         if self.ticks % 64 == 0 {
             // Steal tasks from the global queue to ensure fair task scheduling.


### PR DESCRIPTION
Fix #99. Use `wrapping_add` explicitly to avoid the debug build panic.