### PR TITLE
Fix deadlock when only calling `Executor::tick` to drive it

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -773,6 +773,9 @@ impl Ticker<'_> {
 
 impl Drop for Ticker<'_> {
     fn drop(&mut self) {
+        if let Some(local) = self.state.local_queue.get() {
+            local.waker.take();
+        }
         // If this ticker is in sleeping state, it must be removed from the sleepers list.
         if self.sleeping != 0 {
             let mut sleepers = self.state.sleepers.lock().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -729,6 +729,15 @@ impl Ticker<'_> {
                 .get()
                 .and_then(|local| local.queue.pop().ok())
                 .or_else(|| self.state.queue.pop().ok())
+                .or_else(|| {
+                    // Try popping from each local queue in the list.
+                    for local in self.state.local_queue.iter() {
+                        if let Ok(r) = local.queue.pop() {
+                            return Some(r);
+                        }
+                    }
+                    return None;
+                })
         })
         .await
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -731,12 +731,12 @@ impl Ticker<'_> {
                 .or_else(|| self.state.queue.pop().ok())
                 .or_else(|| {
                     // Try popping from each local queue in the list.
-                    for local in self.state.local_queue.iter() {
-                        if let Ok(r) = local.queue.pop() {
+                    for other in self.state.local_queue.iter() {
+                        if let Ok(r) = other.queue.pop() {
                             return Some(r);
                         }
                     }
-                    return None;
+                    None
                 })
         })
         .await


### PR DESCRIPTION
Pre-1.9.0, you could spawn tasks on one thread, and then manually tick on another without issue since all tasks were queued into the global injector queue. Now that spawn prioritizes local queues over the global injector queue, this no longer works properly. To fix this, this PR changes `Ticker::runnable` to steal one task from the other thread-local queues.

`Ticker::drop` was also not taking and dropping the `Waker` from the thread local queue.