### PR TITLE
v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 1.10.0
+
+- Add a function `spawn_batch` that allows users to spawn multiple tasks while only locking the executor once. (#92)
+
 # Version 1.9.1
 
 - Remove the thread-local optimization due to the bugs that it introduces. (#106)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,8 @@ name = "async-executor"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v1.x.y" git tag
-version = "1.9.1"
-authors = ["Stjepan Glavina <stjepang@gmail.com>"]
+version = "1.10.0"
+authors = ["Stjepan Glavina <stjepang@gmail.com>", "John Nunley <dev@notgull.net>"]
 edition = "2021"
 rust-version = "1.60"
 description = "Async executor"


### PR DESCRIPTION
- Add a function `spawn_batch` that allows users to spawn multiple tasks while only locking the executor once. (#92)
