### PR TITLE
feat: reexport async_task::FallibleTask

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ use futures_lite::{future, prelude::*};
 use slab::Slab;
 
 #[doc(no_inline)]
-pub use async_task::Task;
+pub use async_task::{FallibleTask, Task};
 
 /// An async executor.
 ///


### PR DESCRIPTION
Motivation: FallibleTask is part of the public interface of this crate, in that Task::fallible returns FallibleTask. However, in order to name that type, users need to add a direct dependency on async_task and ensure the crates versions are compatible. Reexporting allows crate users to name the type directly.

Thanks!