### PR TITLE
v1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 1.11.0
+
+- Re-export the `async_task::FallibleTask` primitive. (#113)
+- Support racy initialization of the executor state. This should allow the executor to be
+  initialized on web targets without any issues. (#108)
+
 # Version 1.10.0
 
 - Add a function `spawn_batch` that allows users to spawn multiple tasks while only locking the executor once. (#92)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-executor"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v1.x.y" git tag
-version = "1.10.0"
+version = "1.11.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>", "John Nunley <dev@notgull.net>"]
 edition = "2021"
 rust-version = "1.60"


### PR DESCRIPTION
- Re-export the `async_task::FallibleTask` primitive. (#113)
- Support racy initialization of the executor state. This should allow the executor to be
  initialized on web targets without any issues. (#108)

