### PR TITLE
v1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 1.12.0
+
+- Add static executors, which are an optimization over executors that are kept
+  around forever. (#112)
+
 # Version 1.11.0
 
 - Re-export the `async_task::FallibleTask` primitive. (#113)
@@ -58,7 +63,7 @@
 
 # Version 1.5.1
 
-- Implement a better form of debug output for Executor and LocalExecutor. (#33) 
+- Implement a better form of debug output for Executor and LocalExecutor. (#33)
 
 # Version 1.5.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-executor"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v1.x.y" git tag
-version = "1.11.0"
+version = "1.12.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>", "John Nunley <dev@notgull.net>"]
 edition = "2021"
 rust-version = "1.63"


### PR DESCRIPTION
- Add static executors, which are an optimization over executors that are kept
  around forever. (#112)
