### PR TITLE
remove `Send` bounds on `LocalExecutor::spawn_many`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -563,7 +563,7 @@ impl<'a> LocalExecutor<'a> {
     ///
     /// [`spawn`]: LocalExecutor::spawn
     /// [`Executor::spawn_many`]: Executor::spawn_many
-    pub fn spawn_many<T: Send + 'a, F: Future<Output = T> + Send + 'a>(
+    pub fn spawn_many<T: 'a, F: Future<Output = T> + 'a>(
         &self,
         futures: impl IntoIterator<Item = F>,
         handles: &mut impl Extend<Task<F::Output>>,


### PR DESCRIPTION
Local executors should not restrict futures and their return types as thread-safe.

This pull request removes the `Send` bounds on generic types of function `LocalExecutor::spawn_many`.