### PR TITLE
v1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 1.13.0
+
+- Relax the `Send` bound on `LocalExecutor::spawn_many`. (#120)
+- Ensure all features are documented on `docs.rs`. (#122)
+
 # Version 1.12.0
 
 - Add static executors, which are an optimization over executors that are kept

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-executor"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v1.x.y" git tag
-version = "1.12.0"
+version = "1.13.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>", "John Nunley <dev@notgull.net>"]
 edition = "2021"
 rust-version = "1.63"


### PR DESCRIPTION
- Relax the `Send` bound on `LocalExecutor::spawn_many`. (#120)
- Ensure all features are documented on `docs.rs`. (#122)
