### PR TITLE
Ignore poisoning of `active`

### DIFF
--- a/tests/drop.rs
+++ b/tests/drop.rs
@@ -133,6 +133,9 @@ fn iterator_panics_mid_run() {
         )
     });
     assert!(panic.is_err());
+
+    let task = ex.spawn(future::ready(0));
+    assert_eq!(future::block_on(ex.run(task)), 0);
 }
 
 struct CallOnDrop<F: Fn()>(F);


### PR DESCRIPTION
Closes #135.

This enables the executor to be used in presence of panics in user callbacks, such as the iterator and `impl Extend` in `spawn_many`.

Mutex poisoning is more of a lint than a safety requirement, as containers (such as `Slab`) and wakers have to be sound in presence of panics anyway. In this particular case, the exact behavior of `active` is not relied upon for soundness.