### PR TITLE
Better memory footprint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ async-task = "4.4.0"
 concurrent-queue = "2.5.0"
 fastrand = "2.0.0"
 futures-lite = { version = "2.0.0", default-features = false }
+pin-project-lite = "0.2"
 slab = "0.4.7"
 
 [target.'cfg(target_family = "wasm")'.dependencies]


### PR DESCRIPTION
By creating the future manually instead of relying on `async { .. }`, we workaround rustc's inefficient future layouting. On [a simple benchmark](https://github.com/hez2010/async-runtimes-benchmarks-2024) spawning 1M of tasks, this reduces memory use from about 512 bytes per future to about 340 bytes per future.

More context: https://github.com/hez2010/async-runtimes-benchmarks-2024/pull/1

This PR is rebased onto #136 because tests fail otherwise; please consider that PR first. On this PR, the relevant part for review is the second commit.