### PR TITLE
Release 1.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 1.13.2
+
+- Fix build failure with minimal-versions. (#132)
+- Prevent executor from becoming unusable by panic of the iterator passed by the user to the `spawn_many`. (#136)
+- Reduce memory footprint. (#137)
+
 # Version 1.13.1
 
 - Fix docs.rs build. (#125)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-executor"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v1.x.y" git tag
-version = "1.13.1"
+version = "1.13.2"
 authors = ["Stjepan Glavina <stjepang@gmail.com>", "John Nunley <dev@notgull.net>"]
 edition = "2021"
 rust-version = "1.63"


### PR DESCRIPTION
Changes:

- Fix build failure with minimal-versions. (#132)
- Prevent executor from becoming unusable by panic of the iterator passed by the user to the `spawn_many`. (#136)
- Reduce memory footprint. (#137)