### PR TITLE
Attempt to optimize LocalExecutor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ name = "async-executor"
 version = "1.13.2"
 authors = ["Stjepan Glavina <stjepang@gmail.com>", "John Nunley <dev@notgull.net>"]
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.68"
 description = "Async executor"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/smol-rs/async-executor"
@@ -36,7 +36,7 @@ futures-lite = { version = "2.0.0", default-features = false, features = ["std"]
 async-channel = "2.0.0"
 async-io = "2.1.0"
 async-lock = "3.0.0"
-criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }
+criterion = { version = "0.6", default-features = false, features = ["cargo_bench_support"] }
 easy-parallel = "3.1.0"
 fastrand = "2.0.0"
 futures-lite = "2.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ futures-lite = { version = "2.0.0", default-features = false, features = ["std"]
 async-channel = "2.0.0"
 async-io = "2.1.0"
 async-lock = "3.0.0"
-criterion = { version = "0.6", default-features = false, features = ["cargo_bench_support"] }
+criterion = { version = "0.7", default-features = false, features = ["cargo_bench_support"] }
 easy-parallel = "3.1.0"
 fastrand = "2.0.0"
 futures-lite = "2.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ futures-lite = { version = "2.0.0", default-features = false, features = ["std"]
 async-channel = "2.0.0"
 async-io = "2.1.0"
 async-lock = "3.0.0"
-criterion = { version = "0.7", default-features = false, features = ["cargo_bench_support"] }
+criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }
 easy-parallel = "3.1.0"
 fastrand = "2.0.0"
 futures-lite = "2.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ exclude = ["/.*"]
 # Adds support for executors optimized for use in static variables.
 static = []
 
+[lib]
+bench = false
+
 [dependencies]
 async-task = "4.4.0"
 concurrent-queue = "2.5.0"
@@ -41,6 +44,11 @@ once_cell = "1.16.0"
 
 [[bench]]
 name = "executor"
+harness = false
+required-features = ["static"]
+
+[[bench]]
+name = "local_executor"
 harness = false
 required-features = ["static"]
 

--- a/benches/executor.rs
+++ b/benches/executor.rs
@@ -462,7 +462,9 @@ fn running_benches(c: &mut Criterion) {
                                                     let (resp_send, resp_recv) =
                                                         async_channel::bounded(1);
                                                     db_send.send(resp_send).await.unwrap();
-                                                    black_box(resp_recv.recv().await.unwrap());
+                                                    core::hint::black_box(
+                                                        resp_recv.recv().await.unwrap(),
+                                                    );
                                                 }
 
                                                 // Send the data back...

--- a/benches/executor.rs
+++ b/benches/executor.rs
@@ -462,9 +462,7 @@ fn running_benches(c: &mut Criterion) {
                                                     let (resp_send, resp_recv) =
                                                         async_channel::bounded(1);
                                                     db_send.send(resp_send).await.unwrap();
-                                                    black_box(
-                                                        resp_recv.recv().await.unwrap(),
-                                                    );
+                                                    black_box(resp_recv.recv().await.unwrap());
                                                 }
 
                                                 // Send the data back...

--- a/benches/executor.rs
+++ b/benches/executor.rs
@@ -462,7 +462,7 @@ fn running_benches(c: &mut Criterion) {
                                                     let (resp_send, resp_recv) =
                                                         async_channel::bounded(1);
                                                     db_send.send(resp_send).await.unwrap();
-                                                    core::hint::black_box(
+                                                    black_box(
                                                         resp_recv.recv().await.unwrap(),
                                                     );
                                                 }

--- a/benches/local_executor.rs
+++ b/benches/local_executor.rs
@@ -1,0 +1,426 @@
+use std::mem;
+
+use async_executor::{Executor, LocalExecutor, StaticLocalExecutor};
+use criterion::{criterion_group, criterion_main, Criterion};
+use futures_lite::{future, prelude::*};
+
+const TASKS: usize = 300;
+const STEPS: usize = 300;
+const LIGHT_TASKS: usize = 25_000;
+
+fn run(f: impl FnOnce(&'static LocalExecutor<'_>)) {
+    f(Box::leak(Box::new(LocalExecutor::new())));
+}
+
+fn run_static(f: impl FnOnce(&'static StaticLocalExecutor)) {
+    f(LocalExecutor::new().leak())
+}
+
+fn create(c: &mut Criterion) {
+    c.bench_function("executor::create", |b| {
+        b.iter(|| {
+            let ex = Executor::new();
+            let task = ex.spawn(async {});
+            future::block_on(ex.run(task));
+        })
+    });
+}
+
+fn running_benches(c: &mut Criterion) {
+    for (prefix, with_static) in [("local_executor", false), ("static_local_executor", true)] {
+        let mut group = c.benchmark_group("single_thread");
+
+        group.bench_function(format!("{prefix}::spawn_one"), |b| {
+            if with_static {
+                run_static(|ex| {
+                    b.iter(|| {
+                        let task = ex.spawn(async {});
+                        future::block_on(ex.run(task));
+                    });
+                });
+            } else {
+                run(|ex| {
+                    b.iter(|| {
+                        let task = ex.spawn(async {});
+                        future::block_on(ex.run(task));
+                    });
+                });
+            }
+        });
+
+        if !with_static {
+            group.bench_function("executor::spawn_batch", |b| {
+                run(|ex| {
+                    let mut handles = vec![];
+
+                    b.iter(|| {
+                        ex.spawn_many((0..250).map(|_| future::yield_now()), &mut handles);
+                        handles.clear();
+                    });
+
+                    handles.clear();
+                })
+            });
+        }
+
+        group.bench_function(format!("{prefix}::spawn_many_local"), |b| {
+            if with_static {
+                run_static(|ex| {
+                    b.iter(move || {
+                        future::block_on(ex.run(async {
+                            let mut tasks = Vec::new();
+                            for _ in 0..LIGHT_TASKS {
+                                tasks.push(ex.spawn(async {}));
+                            }
+                            for task in tasks {
+                                task.await;
+                            }
+                        }));
+                    });
+                });
+            } else {
+                run(|ex| {
+                    b.iter(move || {
+                        future::block_on(ex.run(async {
+                            let mut tasks = Vec::new();
+                            for _ in 0..LIGHT_TASKS {
+                                tasks.push(ex.spawn(async {}));
+                            }
+                            for task in tasks {
+                                task.await;
+                            }
+                        }));
+                    });
+                });
+            }
+        });
+
+        group.bench_function(format!("{prefix}::spawn_recursively"), |b| {
+            #[allow(clippy::manual_async_fn)]
+            fn go(
+                ex: &'static LocalExecutor<'static>,
+                i: usize,
+            ) -> impl Future<Output = ()> + 'static {
+                async move {
+                    if i != 0 {
+                        ex.spawn(async move {
+                            let fut = Box::pin(go(ex, i - 1));
+                            fut.await;
+                        })
+                        .await;
+                    }
+                }
+            }
+
+            #[allow(clippy::manual_async_fn)]
+            fn go_static(
+                ex: &'static StaticLocalExecutor,
+                i: usize,
+            ) -> impl Future<Output = ()> + 'static {
+                async move {
+                    if i != 0 {
+                        ex.spawn(async move {
+                            let fut = Box::pin(go_static(ex, i - 1));
+                            fut.await;
+                        })
+                        .await;
+                    }
+                }
+            }
+
+            if with_static {
+                run_static(|ex| {
+                    b.iter(move || {
+                        future::block_on(ex.run(async {
+                            let mut tasks = Vec::new();
+                            for _ in 0..TASKS {
+                                tasks.push(ex.spawn(go_static(ex, STEPS)));
+                            }
+                            for task in tasks {
+                                task.await;
+                            }
+                        }));
+                    });
+                });
+            } else {
+                run(|ex| {
+                    b.iter(move || {
+                        future::block_on(ex.run(async {
+                            let mut tasks = Vec::new();
+                            for _ in 0..TASKS {
+                                tasks.push(ex.spawn(go(ex, STEPS)));
+                            }
+                            for task in tasks {
+                                task.await;
+                            }
+                        }));
+                    });
+                });
+            }
+        });
+
+        group.bench_function(format!("{prefix}::yield_now"), |b| {
+            if with_static {
+                run_static(|ex| {
+                    b.iter(move || {
+                        future::block_on(ex.run(async {
+                            let mut tasks = Vec::new();
+                            for _ in 0..TASKS {
+                                tasks.push(ex.spawn(async move {
+                                    for _ in 0..STEPS {
+                                        future::yield_now().await;
+                                    }
+                                }));
+                            }
+                            for task in tasks {
+                                task.await;
+                            }
+                        }));
+                    });
+                });
+            } else {
+                run(|ex| {
+                    b.iter(move || {
+                        future::block_on(ex.run(async {
+                            let mut tasks = Vec::new();
+                            for _ in 0..TASKS {
+                                tasks.push(ex.spawn(async move {
+                                    for _ in 0..STEPS {
+                                        future::yield_now().await;
+                                    }
+                                }));
+                            }
+                            for task in tasks {
+                                task.await;
+                            }
+                        }));
+                    });
+                });
+            }
+        });
+
+        group.bench_function(format!("{prefix}::channels"), |b| {
+            if with_static {
+                run_static(|ex| {
+                    b.iter(move || {
+                        future::block_on(ex.run(async {
+                            // Create channels.
+                            let mut tasks = Vec::new();
+                            let (first_send, first_recv) = async_channel::bounded(1);
+                            let mut current_recv = first_recv;
+
+                            for _ in 0..TASKS {
+                                let (next_send, next_recv) = async_channel::bounded(1);
+                                let current_recv = mem::replace(&mut current_recv, next_recv);
+
+                                tasks.push(ex.spawn(async move {
+                                    // Send a notification on to the next task.
+                                    for _ in 0..STEPS {
+                                        current_recv.recv().await.unwrap();
+                                        next_send.send(()).await.unwrap();
+                                    }
+                                }));
+                            }
+
+                            for _ in 0..STEPS {
+                                first_send.send(()).await.unwrap();
+                                current_recv.recv().await.unwrap();
+                            }
+
+                            for task in tasks {
+                                task.await;
+                            }
+                        }));
+                    });
+                })
+            } else {
+                run(|ex| {
+                    b.iter(move || {
+                        future::block_on(ex.run(async {
+                            // Create channels.
+                            let mut tasks = Vec::new();
+                            let (first_send, first_recv) = async_channel::bounded(1);
+                            let mut current_recv = first_recv;
+
+                            for _ in 0..TASKS {
+                                let (next_send, next_recv) = async_channel::bounded(1);
+                                let current_recv = mem::replace(&mut current_recv, next_recv);
+
+                                tasks.push(ex.spawn(async move {
+                                    // Send a notification on to the next task.
+                                    for _ in 0..STEPS {
+                                        current_recv.recv().await.unwrap();
+                                        next_send.send(()).await.unwrap();
+                                    }
+                                }));
+                            }
+
+                            for _ in 0..STEPS {
+                                first_send.send(()).await.unwrap();
+                                current_recv.recv().await.unwrap();
+                            }
+
+                            for task in tasks {
+                                task.await;
+                            }
+                        }));
+                    });
+                })
+            }
+        });
+
+        group.bench_function(format!("{prefix}::web_server"), |b| {
+            if with_static {
+                run_static(|ex| {
+                    b.iter(move || {
+                        future::block_on(ex.run(async {
+                            let (db_send, db_recv) =
+                                async_channel::bounded::<async_channel::Sender<_>>(TASKS / 5);
+                            let mut db_rng = fastrand::Rng::with_seed(0x12345678);
+                            let mut web_rng = db_rng.fork();
+
+                            // This task simulates a database.
+                            let db_task = ex.spawn(async move {
+                                loop {
+                                    // Wait for a new task.
+                                    let incoming = match db_recv.recv().await {
+                                        Ok(incoming) => incoming,
+                                        Err(_) => break,
+                                    };
+
+                                    // Process the task. Maybe it takes a while.
+                                    for _ in 0..db_rng.usize(..10) {
+                                        future::yield_now().await;
+                                    }
+
+                                    // Send the data back.
+                                    incoming.send(db_rng.usize(..)).await.ok();
+                                }
+                            });
+
+                            // This task simulates a web server waiting for new tasks.
+                            let server_task = ex.spawn(async move {
+                                for i in 0..TASKS {
+                                    // Get a new connection.
+                                    if web_rng.usize(..=16) == 16 {
+                                        future::yield_now().await;
+                                    }
+
+                                    let mut web_rng = web_rng.fork();
+                                    let db_send = db_send.clone();
+                                    let task = ex.spawn(async move {
+                                        // Check if the data is cached...
+                                        if web_rng.bool() {
+                                            // ...it's in cache!
+                                            future::yield_now().await;
+                                            return;
+                                        }
+
+                                        // Otherwise we have to make a DB call or two.
+                                        for _ in 0..web_rng.usize(STEPS / 2..STEPS) {
+                                            let (resp_send, resp_recv) = async_channel::bounded(1);
+                                            db_send.send(resp_send).await.unwrap();
+                                            criterion::black_box(resp_recv.recv().await.unwrap());
+                                        }
+
+                                        // Send the data back...
+                                        for _ in 0..web_rng.usize(3..16) {
+                                            future::yield_now().await;
+                                        }
+                                    });
+
+                                    task.detach();
+
+                                    if i & 16 == 0 {
+                                        future::yield_now().await;
+                                    }
+                                }
+                            });
+
+                            // Spawn and wait for it to stop.
+                            server_task.await;
+                            db_task.await;
+                        }));
+                    })
+                })
+            } else {
+                run(|ex| {
+                    b.iter(move || {
+                        future::block_on(ex.run(async {
+                            let (db_send, db_recv) =
+                                async_channel::bounded::<async_channel::Sender<_>>(TASKS / 5);
+                            let mut db_rng = fastrand::Rng::with_seed(0x12345678);
+                            let mut web_rng = db_rng.fork();
+
+                            // This task simulates a database.
+                            let db_task = ex.spawn(async move {
+                                loop {
+                                    // Wait for a new task.
+                                    let incoming = match db_recv.recv().await {
+                                        Ok(incoming) => incoming,
+                                        Err(_) => break,
+                                    };
+
+                                    // Process the task. Maybe it takes a while.
+                                    for _ in 0..db_rng.usize(..10) {
+                                        future::yield_now().await;
+                                    }
+
+                                    // Send the data back.
+                                    incoming.send(db_rng.usize(..)).await.ok();
+                                }
+                            });
+
+                            // This task simulates a web server waiting for new tasks.
+                            let server_task = ex.spawn(async move {
+                                for i in 0..TASKS {
+                                    // Get a new connection.
+                                    if web_rng.usize(..=16) == 16 {
+                                        future::yield_now().await;
+                                    }
+
+                                    let mut web_rng = web_rng.fork();
+                                    let db_send = db_send.clone();
+                                    let task = ex.spawn(async move {
+                                        // Check if the data is cached...
+                                        if web_rng.bool() {
+                                            // ...it's in cache!
+                                            future::yield_now().await;
+                                            return;
+                                        }
+
+                                        // Otherwise we have to make a DB call or two.
+                                        for _ in 0..web_rng.usize(STEPS / 2..STEPS) {
+                                            let (resp_send, resp_recv) = async_channel::bounded(1);
+                                            db_send.send(resp_send).await.unwrap();
+                                            criterion::black_box(resp_recv.recv().await.unwrap());
+                                        }
+
+                                        // Send the data back...
+                                        for _ in 0..web_rng.usize(3..16) {
+                                            future::yield_now().await;
+                                        }
+                                    });
+
+                                    task.detach();
+
+                                    if i & 16 == 0 {
+                                        future::yield_now().await;
+                                    }
+                                }
+                            });
+
+                            // Spawn and wait for it to stop.
+                            server_task.await;
+                            db_task.await;
+                        }));
+                    })
+                })
+            }
+        });
+    }
+}
+
+criterion_group!(benches, create, running_benches);
+
+criterion_main!(benches);

--- a/benches/local_executor.rs
+++ b/benches/local_executor.rs
@@ -1,4 +1,5 @@
 use std::mem;
+use std::hint::black_box;
 
 use async_executor::{Executor, LocalExecutor, StaticLocalExecutor};
 use criterion::{criterion_group, criterion_main, Criterion};
@@ -320,7 +321,7 @@ fn running_benches(c: &mut Criterion) {
                                         for _ in 0..web_rng.usize(STEPS / 2..STEPS) {
                                             let (resp_send, resp_recv) = async_channel::bounded(1);
                                             db_send.send(resp_send).await.unwrap();
-                                            core::hint::black_box(resp_recv.recv().await.unwrap());
+                                            black_box(resp_recv.recv().await.unwrap());
                                         }
 
                                         // Send the data back...
@@ -393,7 +394,7 @@ fn running_benches(c: &mut Criterion) {
                                         for _ in 0..web_rng.usize(STEPS / 2..STEPS) {
                                             let (resp_send, resp_recv) = async_channel::bounded(1);
                                             db_send.send(resp_send).await.unwrap();
-                                            core::hint::black_box(resp_recv.recv().await.unwrap());
+                                            black_box(resp_recv.recv().await.unwrap());
                                         }
 
                                         // Send the data back...

--- a/benches/local_executor.rs
+++ b/benches/local_executor.rs
@@ -320,7 +320,7 @@ fn running_benches(c: &mut Criterion) {
                                         for _ in 0..web_rng.usize(STEPS / 2..STEPS) {
                                             let (resp_send, resp_recv) = async_channel::bounded(1);
                                             db_send.send(resp_send).await.unwrap();
-                                            criterion::black_box(resp_recv.recv().await.unwrap());
+                                            core::hint::black_box(resp_recv.recv().await.unwrap());
                                         }
 
                                         // Send the data back...
@@ -393,7 +393,7 @@ fn running_benches(c: &mut Criterion) {
                                         for _ in 0..web_rng.usize(STEPS / 2..STEPS) {
                                             let (resp_send, resp_recv) = async_channel::bounded(1);
                                             db_send.send(resp_send).await.unwrap();
-                                            criterion::black_box(resp_recv.recv().await.unwrap());
+                                            core::hint::black_box(resp_recv.recv().await.unwrap());
                                         }
 
                                         // Send the data back...

--- a/benches/local_executor.rs
+++ b/benches/local_executor.rs
@@ -1,5 +1,5 @@
-use std::mem;
 use std::hint::black_box;
+use std::mem;
 
 use async_executor::{Executor, LocalExecutor, StaticLocalExecutor};
 use criterion::{criterion_group, criterion_main, Criterion};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -923,7 +923,7 @@ struct AbortOnPanic;
 impl Drop for AbortOnPanic {
     fn drop(&mut self) {
         // Panicking while already panicking will result in an abort
-        panic!("Panicked while in a critical section. Abortign the process");
+        panic!("Panicked while in a critical section. Aborting the process");
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -918,6 +918,15 @@ fn debug_state(state: &State, name: &str, f: &mut fmt::Formatter<'_>) -> fmt::Re
         .finish()
 }
 
+struct AbortOnPanic;
+
+impl Drop for AbortOnPanic {
+    fn drop(&mut self) {
+        // Panicking while already panicking will result in an abort
+        panic!("Panicked while in a critical section. Abortign the process");
+    }
+}
+
 /// Runs a closure when dropped.
 struct CallOnDrop<F: FnMut()>(F);
 

--- a/src/local_executor.rs
+++ b/src/local_executor.rs
@@ -152,9 +152,9 @@ impl<'a> LocalExecutor<'a> {
         let mut active = self.state().active();
 
         // Convert the futures into tasks.
-        let tasks = futures.into_iter().map(move |future| {
-            self.spawn_inner(future, &mut active)
-        });
+        let tasks = futures
+            .into_iter()
+            .map(move |future| self.spawn_inner(future, &mut active));
 
         // Push the tasks to the user's collection.
         handles.extend(tasks);
@@ -190,16 +190,16 @@ impl<'a> LocalExecutor<'a> {
         // the `Executor` is drained of all of its runnables. This ensures that
         // runnables are dropped and this precondition is satisfied.
         //
-        // `self.schedule()` is not `Send` nor `Sync`. As LocalExecutor is not 
+        // `self.schedule()` is not `Send` nor `Sync`. As LocalExecutor is not
         // `Send`, the `Waker` is guaranteed// to only be used on the same thread
         // it was spawned on.
         //
-        // `self.schedule()` is `'static`, and thus will outlive all borrowed 
+        // `self.schedule()` is `'static`, and thus will outlive all borrowed
         // variables in the future.
         let (runnable, task) = unsafe {
             Builder::new()
-            .propagate_panic(true)
-            .spawn_unchecked(|()| future, self.schedule())
+                .propagate_panic(true)
+                .spawn_unchecked(|()| future, self.schedule())
         };
         entry.insert(runnable.waker());
 
@@ -407,7 +407,9 @@ impl State {
         // A future that runs tasks forever.
         let run_forever = async {
             loop {
-                ticker.runnable().await.run();
+                for _ in 0..200 {
+                    ticker.runnable().await.run();
+                }
                 future::yield_now().await;
             }
         };

--- a/src/local_executor.rs
+++ b/src/local_executor.rs
@@ -33,7 +33,7 @@ pub use async_task::Task;
 /// ```
 pub struct LocalExecutor<'a> {
     /// The executor state.
-    state: Cell<*mut State>,
+    pub(crate) state: Cell<*mut State>,
 
     /// Makes the `'a` lifetime invariant.
     _marker: PhantomData<UnsafeCell<&'a ()>>,

--- a/src/local_executor.rs
+++ b/src/local_executor.rs
@@ -35,7 +35,7 @@ pub struct LocalExecutor<'a> {
     state: Cell<*mut State>,
 
     /// Makes the `'a` lifetime invariant.
-    _marker: PhantomData<std::cell::UnsafeCell<&'a ()>>,
+    _marker: PhantomData<UnsafeCell<&'a ()>>,
 }
 
 impl UnwindSafe for LocalExecutor<'_> {}

--- a/src/local_executor.rs
+++ b/src/local_executor.rs
@@ -213,8 +213,9 @@ impl<'a> LocalExecutor<'a> {
         // `Send`, the `Waker` is guaranteed// to only be used on the same thread
         // it was spawned on.
         //
-        // `schedule` is `'static`, and thus will outlive all borrowed
-        // variables in the future.
+        // `Self::schedule` may not be `'static`, but we make sure that the `Waker` does
+        // not outlive `'a`. When the executor is dropped, the `active` field is
+        // drained and all of the `Waker`s are woken.
         let (runnable, task) = unsafe {
             Builder::new()
                 .propagate_panic(true)

--- a/src/local_executor.rs
+++ b/src/local_executor.rs
@@ -327,11 +327,11 @@ impl<'a> LocalExecutor<'a> {
         unsafe { &*self.state_ptr() }
     }
 
-    // Clones the inner state Arc
+    // Clones the inner state Rc
     #[inline]
     fn state_as_rc(&self) -> Rc<State> {
         // SAFETY: So long as a LocalExecutor lives, it's state pointer will always be a valid
-        // Arc when accessed through state_ptr.
+        // Rc when accessed through state_ptr.
         let rc = unsafe { Rc::from_raw(self.state_ptr()) };
         let clone = rc.clone();
         std::mem::forget(rc);
@@ -346,8 +346,8 @@ impl Drop for LocalExecutor<'_> {
             return;
         }
 
-        // SAFETY: As ptr is not null, it was allocated via Arc::new and converted
-        // via Arc::into_raw in state_ptr.
+        // SAFETY: As ptr is not null, it was allocated via Rc::new and converted
+        // via Rc::into_raw in state_ptr.
         let state = unsafe { Rc::from_raw(ptr) };
 
         {
@@ -585,7 +585,7 @@ fn debug_executor(
     }
 
     // SAFETY: If the state pointer is not null, it must have been
-    // allocated properly by Arc::new and converted via Arc::into_raw
+    // allocated properly by Rc::new and converted via Rc::into_raw
     // in state_ptr.
     let state = unsafe { &*ptr };
 

--- a/src/local_executor.rs
+++ b/src/local_executor.rs
@@ -108,7 +108,7 @@ impl<'a> LocalExecutor<'a> {
         // SAFETY: All UnsafeCell accesses to active are tightly scoped, and because
         // `LocalExecutor` is !Send, there is no way to have concurrent access to the
         // values in `State`, including the active field.
-        let active = unsafe { &mut *self.state().active.get() };
+        let active = unsafe { &mut *state.active.get() };
         Self::spawn_inner(state, future, active)
     }
 

--- a/src/static_executors.rs
+++ b/src/static_executors.rs
@@ -88,7 +88,7 @@ impl LocalExecutor<'static> {
         let ptr = self.state.get();
 
         let state: &'static LocalState = if ptr.is_null() {
-            Box::leak(Box::new(LocalState::new())) 
+            Box::leak(Box::new(LocalState::new()))
         } else {
             // SAFETY: So long as a LocalExecutor lives, it's state pointer will always be valid
             // when accessed through state_ptr. This executor will live for the full 'static

--- a/src/static_executors.rs
+++ b/src/static_executors.rs
@@ -417,11 +417,11 @@ impl StaticLocalExecutor {
         // `future` is not `'static`, but the caller guarantees that the
         //  task, and thus its `Runnable` must not live longer than `'a`.
         //
-        // `self.schedule()` is not `Send` nor `Sync`. As StaticLocalExecutor is not 
+        // `self.schedule()` is not `Send` nor `Sync`. As StaticLocalExecutor is not
         // `Send`, the `Waker` is guaranteed// to only be used on the same thread
         // it was spawned on.
         //
-        // `self.schedule()` is `'static`, and thus will outlive all borrowed 
+        // `self.schedule()` is `'static`, and thus will outlive all borrowed
         // variables in the future.
         let (runnable, task) = unsafe {
             Builder::new()

--- a/tests/larger_tasks.rs
+++ b/tests/larger_tasks.rs
@@ -5,6 +5,7 @@ use futures_lite::future::{self, block_on};
 use futures_lite::prelude::*;
 
 use std::sync::Arc;
+use std::rc::Rc;
 use std::thread;
 use std::time::Duration;
 
@@ -99,7 +100,7 @@ fn do_run_local<Fut: Future<Output = ()>>(mut f: impl FnMut(Arc<LocalExecutor<'s
         stop_timeout
     };
 
-    let ex = Arc::new(LocalExecutor::new());
+    let ex = Rc::new(LocalExecutor::new());
 
     // Test 1: Use the `run` command.
     block_on(ex.run(f(ex.clone())));

--- a/tests/larger_tasks.rs
+++ b/tests/larger_tasks.rs
@@ -4,8 +4,8 @@ use async_executor::{Executor, LocalExecutor};
 use futures_lite::future::{self, block_on};
 use futures_lite::prelude::*;
 
-use std::sync::Arc;
 use std::rc::Rc;
+use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
@@ -81,7 +81,7 @@ fn do_run<Fut: Future<Output = ()>>(mut f: impl FnMut(Arc<Executor<'static>>) ->
     });
 }
 
-fn do_run_local<Fut: Future<Output = ()>>(mut f: impl FnMut(Arc<LocalExecutor<'static>>) -> Fut) {
+fn do_run_local<Fut: Future<Output = ()>>(mut f: impl FnMut(Rc<LocalExecutor<'static>>) -> Fut) {
     // This should not run for longer than two minutes.
     #[cfg(not(miri))]
     let _stop_timeout = {

--- a/tests/local_queue.rs
+++ b/tests/local_queue.rs
@@ -1,4 +1,4 @@
-use async_executor::Executor;
+use async_executor::{Executor, LocalExecutor};
 use futures_lite::{future, pin};
 
 #[test]
@@ -6,6 +6,28 @@ fn two_queues() {
     future::block_on(async {
         // Create an executor with two runners.
         let ex = Executor::new();
+        let (run1, run2) = (
+            ex.run(future::pending::<()>()),
+            ex.run(future::pending::<()>()),
+        );
+        let mut run1 = Box::pin(run1);
+        pin!(run2);
+
+        // Poll them both.
+        assert!(future::poll_once(run1.as_mut()).await.is_none());
+        assert!(future::poll_once(run2.as_mut()).await.is_none());
+
+        // Drop the first one, which should leave the local queue in the `None` state.
+        drop(run1);
+        assert!(future::poll_once(run2.as_mut()).await.is_none());
+    });
+}
+
+#[test]
+fn local_two_queues() {
+    future::block_on(async {
+        // Create an executor with two runners.
+        let ex = LocalExecutor::new();
         let (run1, run2) = (
             ex.run(future::pending::<()>()),
             ex.run(future::pending::<()>()),

--- a/tests/panic_prop.rs
+++ b/tests/panic_prop.rs
@@ -1,9 +1,21 @@
-use async_executor::Executor;
+use async_executor::{Executor, LocalExecutor};
 use futures_lite::{future, prelude::*};
 
 #[test]
 fn test_panic_propagation() {
     let ex = Executor::new();
+    let task = ex.spawn(async { panic!("should be caught by the task") });
+
+    // Running the executor should not panic.
+    assert!(ex.try_tick());
+
+    // Polling the task should.
+    assert!(future::block_on(task.catch_unwind()).is_err());
+}
+
+#[test]
+fn test_local_panic_propagation() {
+    let ex = LocalExecutor::new();
     let task = ex.spawn(async { panic!("should be caught by the task") });
 
     // Running the executor should not panic.


### PR DESCRIPTION
This PR makes `LocalExecutor` it's own separate implementation instead of wrapping an Executor, forking it's own `State` type utilizing unsynchronized `!Send` types where possible: `Arc` -> `Rc`, `Mutex` -> `RefCell`, `AtomicPtr` -> `Cell<*mut T>`, `ConcurrentQueue` -> `VecDeque`. This implementation also removes any extra operations that assumes there are other concurrent Runners/Tickers (i.e. local queues, extra notifications). 

For testing, I've duplicated most of the single-threaded compatible executor tests to ensure there's equivalent coverage on the new independent `LocalExecutor`.

I've also made an attempt to write this with `UnsafeCell` instead of `RefCell`, but this litters a huge amount of `unsafe` that might be too much for this crate. The gains here might not be worth it.

I previously wrote some additional benchmarks but lost the changes to a stray `git reset --hard` when benchmarking. 
The gains here are substantial. Here are the results:

```
single_thread/local_executor::spawn_one
                        time:   [130.05 ns 130.98 ns 132.16 ns]
                        change: [-80.586% -80.413% -80.214%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  4 (4.00%) high mild
  10 (10.00%) high severe
single_thread/local_executor::spawn_batch
                        time:   [17.195 µs 22.167 µs 32.281 µs]
                        change: [-30.007% +0.4082% +41.137%] (p = 0.98 > 0.05)
                        No change in performance detected.
Found 17 outliers among 100 measurements (17.00%)
  7 (7.00%) high mild
  10 (10.00%) high severe
Benchmarking single_thread/local_executor::spawn_many_local: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 856.5s, or reduce sample count to 10.
single_thread/local_executor::spawn_many_local
                        time:   [2.7766 ms 2.8091 ms 2.8453 ms]
                        change: [-21.653% -8.5454% +6.4249%] (p = 0.30 > 0.05)
                        No change in performance detected.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe
single_thread/local_executor::spawn_recursively
                        time:   [19.618 ms 20.071 ms 20.558 ms]
                        change: [-24.237% -22.461% -20.762%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  6 (6.00%) high mild
Benchmarking single_thread/local_executor::yield_now: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.7s, enable flat sampling, or reduce sample count to 50.
single_thread/local_executor::yield_now
                        time:   [1.8382 ms 1.8421 ms 1.8470 ms]
                        change: [-52.888% -52.744% -52.570%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) high mild
  9 (9.00%) high severe
single_thread/local_executor::channels
                        time:   [9.9259 ms 9.9355 ms 9.9452 ms]
                        change: [-15.797% -15.656% -15.533%] (p = 0.00 < 0.05)
                        Performance has improved.
single_thread/local_executor::web_server
                        time:   [54.839 µs 56.776 µs 59.062 µs]
                        change: [-23.926% -18.725% -13.009%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe
```
