### PR TITLE
Directly schedule tasks instead of using Runnable::schedule

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ exclude = ["/.*"]
 # Adds support for executors optimized for use in static variables.
 static = []
 
+[lib]
+bench = false
+
 [dependencies]
 async-task = "4.4.0"
 concurrent-queue = "2.5.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,7 +282,10 @@ impl<'a> Executor<'a> {
             .spawn_unchecked(|()| future, Self::schedule(state));
         entry.insert(runnable.waker());
 
-        runnable.schedule();
+        // `Runnable::schedule` has an extra clone/drop of the Waker, which can
+        // be skipped by directly scheduling instead of calling `Runnable::schedule`.
+        Self::schedule_runnable(&state, runnable);
+
         task
     }
 
@@ -353,10 +356,14 @@ impl<'a> Executor<'a> {
     fn schedule(state: Pin<&'a State>) -> impl Fn(Runnable) + Send + Sync + 'a {
         // TODO: If possible, push into the current local queue and notify the ticker.
         move |runnable| {
-            let result = state.queue.push(runnable);
-            debug_assert!(result.is_ok()); // Since we use unbounded queue, push will never fail.
-            state.notify();
+            Self::schedule_runnable(&state, runnable);
         }
+    }
+
+    fn schedule_runnable(state: &State, runnable: Runnable) {
+        let result = state.queue.push(runnable);
+        debug_assert!(result.is_ok()); // Since we use unbounded queue, push will never fail.
+        state.notify();
     }
 
     /// Returns a pointer to the inner state.

--- a/src/static_executors.rs
+++ b/src/static_executors.rs
@@ -192,7 +192,11 @@ impl StaticExecutor {
         let (runnable, task) = Builder::new()
             .propagate_panic(true)
             .spawn(|()| future, self.schedule());
-        runnable.schedule();
+
+        // `Runnable::schedule` has an extra clone/drop of the Waker, which can
+        // be skipped by directly scheduling instead of calling `Runnable::schedule`.
+        Self::schedule_runnable(&self.state, runnable);
+
         task
     }
 
@@ -219,7 +223,11 @@ impl StaticExecutor {
                 .propagate_panic(true)
                 .spawn_unchecked(|()| future, self.schedule())
         };
-        runnable.schedule();
+
+        // `Runnable::schedule` has an extra clone/drop of the Waker, which can
+        // be skipped by directly scheduling instead of calling `Runnable::schedule`.
+        Self::schedule_runnable(&self.state, runnable);
+
         task
     }
 
@@ -294,10 +302,15 @@ impl StaticExecutor {
         let state: &'static State = &self.state;
         // TODO: If possible, push into the current local queue and notify the ticker.
         move |runnable| {
-            let result = state.queue.push(runnable);
-            debug_assert!(result.is_ok()); // Since we use unbounded queue, push will never fail.
-            state.notify();
+            Self::schedule_runnable(state, runnable);
         }
+    }
+
+    #[inline]
+    fn schedule_runnable(state: &'static State, runnable: Runnable) {
+        let result = state.queue.push(runnable);
+        debug_assert!(result.is_ok()); // Since we use unbounded queue, push will never fail.
+        state.notify();
     }
 }
 
@@ -375,7 +388,11 @@ impl StaticLocalExecutor {
         let (runnable, task) = Builder::new()
             .propagate_panic(true)
             .spawn_local(|()| future, self.schedule());
-        runnable.schedule();
+
+        // `Runnable::schedule` has an extra clone/drop of the Waker, which can
+        // be skipped by directly scheduling instead of calling `Runnable::schedule`.
+        Self::schedule_runnable(&self.state, runnable);
+
         task
     }
 
@@ -408,7 +425,11 @@ impl StaticLocalExecutor {
                 .propagate_panic(true)
                 .spawn_unchecked(|()| future, self.schedule())
         };
-        runnable.schedule();
+
+        // `Runnable::schedule` has an extra clone/drop of the Waker, which can
+        // be skipped by directly scheduling instead of calling `Runnable::schedule`.
+        Self::schedule_runnable(&self.state, runnable);
+
         task
     }
 
@@ -480,10 +501,15 @@ impl StaticLocalExecutor {
         let state: &'static State = &self.state;
         // TODO: If possible, push into the current local queue and notify the ticker.
         move |runnable| {
-            let result = state.queue.push(runnable);
-            debug_assert!(result.is_ok()); // Since we use unbounded queue, push will never fail.
-            state.notify();
+            Self::schedule_runnable(state, runnable);
         }
+    }
+
+    #[inline]
+    fn schedule_runnable(state: &'static State, runnable: Runnable) {
+        let result = state.queue.push(runnable);
+        debug_assert!(result.is_ok()); // Since we use unbounded queue, push will never fail.
+        state.notify();
     }
 }
 


### PR DESCRIPTION
`async_task::Runnable::schedule` has [an "extra" Waker clone and drop](https://github.com/smol-rs/async-task/blob/a11c4b22cbcbbdbc4fa0ff62bdbffb430a9d3394/src/raw.rs#L430-L435) whenever the `schedule` function for the task captures variables to avoid deallocation during scheduling. We can avoid this by just... directly scheduling the `Runnable` with the references that already exist. This PR just splits out the schedule functions into their own static functions and invokes that directly than go through `Runnable::schedule`. Benchmarking results:

```
group                                               direct-schedule                         master
-----                                               ---------------                         ------
executor::create                                    1.00    879.8±9.33ns        ? ?/sec     1.01   884.3±10.50ns        ? ?/sec
multi_thread/executor::channels                     1.00     42.6±1.13ms        ? ?/sec     1.02     43.3±1.69ms        ? ?/sec
multi_thread/executor::spawn_batch                  1.00     28.8±7.70µs        ? ?/sec     1.14     32.7±4.87µs        ? ?/sec
multi_thread/executor::spawn_many_local             1.00     13.9±0.92ms        ? ?/sec     1.10     15.2±1.45ms        ? ?/sec
multi_thread/executor::spawn_one                    1.00   938.5±37.02ns        ? ?/sec     1.12  1046.5±115.88ns        ? ?/sec
multi_thread/executor::spawn_recursively            1.00    137.0±1.26ms        ? ?/sec     1.03    140.5±1.37ms        ? ?/sec
multi_thread/executor::web_server                   1.00     59.7±2.47ms        ? ?/sec     1.05     62.4±3.92ms        ? ?/sec
multi_thread/executor::yield_now                    1.00     20.5±0.19ms        ? ?/sec     1.00     20.5±0.74ms        ? ?/sec
multi_thread/static_executor::channels              1.00     42.5±1.42ms        ? ?/sec     1.05     44.5±4.32ms        ? ?/sec
multi_thread/static_executor::spawn_many_local      1.00      2.9±0.29ms        ? ?/sec     1.08      3.2±0.20ms        ? ?/sec
multi_thread/static_executor::spawn_one             1.00  1079.3±81.93ns        ? ?/sec     1.05  1138.7±154.83ns        ? ?/sec
multi_thread/static_executor::spawn_recursively     1.01     38.4±0.34ms        ? ?/sec     1.00     38.0±1.08ms        ? ?/sec
multi_thread/static_executor::web_server            1.00     59.4±1.01ms        ? ?/sec     1.05     62.3±2.73ms        ? ?/sec
multi_thread/static_executor::yield_now             1.00     20.4±0.43ms        ? ?/sec     1.01     20.5±0.56ms        ? ?/sec
single_thread/executor::channels                    1.00     14.7±0.35ms        ? ?/sec     1.23     18.0±0.84ms        ? ?/sec
single_thread/executor::spawn_batch                 1.00     18.3±8.77µs        ? ?/sec     1.05    19.3±11.16µs        ? ?/sec
single_thread/executor::spawn_many_local            1.00      4.6±0.49ms        ? ?/sec     1.08      4.9±0.46ms        ? ?/sec
single_thread/executor::spawn_one                   1.03  1468.8±163.70ns        ? ?/sec    1.00  1426.0±64.37ns        ? ?/sec
single_thread/executor::spawn_recursively           1.00     21.8±1.14ms        ? ?/sec     1.13     24.6±1.61ms        ? ?/sec
single_thread/executor::web_server                  1.00     22.5±0.31ms        ? ?/sec     1.10     24.8±3.46ms        ? ?/sec
single_thread/executor::yield_now                   1.00      4.0±0.04ms        ? ?/sec     1.09      4.4±0.23ms        ? ?/sec
single_thread/static_executor::channels             1.00     17.1±0.96ms        ? ?/sec     1.11     19.0±1.92ms        ? ?/sec
single_thread/static_executor::spawn_many_local     1.00  1887.9±89.21µs        ? ?/sec     1.22      2.3±0.09ms        ? ?/sec
single_thread/static_executor::spawn_one            1.00  962.6±510.98ns        ? ?/sec     1.13  1091.9±653.42ns        ? ?/sec
single_thread/static_executor::spawn_recursively    1.00     17.8±1.12ms        ? ?/sec     1.19     21.1±2.51ms        ? ?/sec
single_thread/static_executor::web_server           1.00     22.8±0.61ms        ? ?/sec     1.06     24.2±1.93ms        ? ?/sec
single_thread/static_executor::yield_now            1.00      4.1±0.26ms        ? ?/sec     1.04      4.3±0.17ms        ? ?/sec
```

This seems to have a strong impact on the executor types that already have low spawning overhead (i.e. the StaticExecutors). Rerunning the benchmarks does seem to show some noise when testing for improvements, but overall generally seems to bias towards directly scheduling with at least a  5-10% perf gain on most of these benchmarks.

--- 

**Commentary:** I really dislike the fact that this is necessary to optimize the executors here. `Runnable::schedule` otherwise doesn't really have a reason to exist as an API if it's just going to be less efficient than directly scheduling the task. I suspect this is a combination of a lack of inlining due to dynamic dispatch (not sure why Rust does not devirtualize this call) and the lack of overhead form cloning the waker and dropping it to keep the task alive during scheduling. Not sure if it's advisable to update guidance for `async-task` based on this.