### PR TITLE
Fix failing docs build

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/smol-rs/smol/master/assets/images/logo_fullsize_transparent.png"
 )]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(clippy::unused_unit)] // false positive fixed in Rust 1.89
 
 use std::fmt;


### PR DESCRIPTION
The `doc_auto_cfg` attribute has been renamed to `doc_cfg`
See https://github.com/rust-lang/rust/issues/43781