### PR TITLE
Release 1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Version 1.14.0
+
+- Bump MSRV to 1.65. (#146)
+- Fix docs.rs build. (#152)
+- Upstreaming parts of the Hermit `no_std` patchset:
+  - Use `Self` where possible (#155)
+  - Import items from `core` and `alloc` if possible (#160)
+
 # Version 1.13.3
 
 - Avoid places where the code had a possibility to block or panic. (#147)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-executor"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v1.x.y" git tag
-version = "1.13.3"
+version = "1.14.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>", "John Nunley <dev@notgull.net>"]
 edition = "2021"
 rust-version = "1.65"


### PR DESCRIPTION
Changes:
- Bump MSRV to 1.65. (#146)
- Fix docs.rs build. (#152)
- Upstreaming parts of the Hermit `no_std` patchset:
  - Use `Self` where possible (#155)
  - Import items from `core` and `alloc` if possible (#160)