### PR TITLE
chore: add `use Box` (for no-std compatibility)

### DIFF
--- a/src/static_executors.rs
+++ b/src/static_executors.rs
@@ -1,4 +1,5 @@
 use crate::{debug_state, Executor, LocalExecutor, State};
+use alloc::boxed::Box;
 use async_task::{Builder, Runnable, Task};
 use core::{
     cell::UnsafeCell,


### PR DESCRIPTION
Cherry-picked from #161 (because that one breaks backwards-compatibility).